### PR TITLE
do not add build number to the tag is it's not a real number

### DIFF
--- a/tasks/git.js
+++ b/tasks/git.js
@@ -49,14 +49,19 @@ function Git(grunt) {
      * @returns newVersion The new version.
      */
     function getNewVersion(cwd, buildNumber) {
-        var version = getVersion(cwd),
+        var buildNo = parseInt(buildNumber),
+            version = getVersion(cwd),
             sha = getSha(cwd),
             newVersion;
 
+        if(isNaN(buildNo)) {
+            buildNo = undefined;
+        }
+
         if(version) {
             newVersion = version;
-            if(buildNumber && sha) {
-                newVersion = newVersion.concat('-build.' + buildNumber + '+sha.' + sha);
+            if(buildNo && sha) {
+                newVersion = newVersion.concat('-build.' + buildNo + '+sha.' + sha);
             }
         }
         return newVersion;

--- a/test/releasePrepareSpec.js
+++ b/test/releasePrepareSpec.js
@@ -35,7 +35,8 @@ describe('ReleaseMe', function () {
 
         function releaseMe(configuration) {
             var hasWd = configuration.wd !== undefined;
-            var hasBuildNumber = configuration.buildNumber !== undefined;
+            var buildNo = parseInt(configuration.buildNumber);
+            var hasBuildNumber = !isNaN(buildNo);
             var hasMainArray = configuration.main instanceof Array;
             var newVersion = '0.1.1' + (hasBuildNumber ? '-build.' + configuration.buildNumber + '+sha.6283298' : '');
             release.me(configuration, function () {
@@ -133,9 +134,23 @@ describe('ReleaseMe', function () {
             });
         });
 
-        it('when a no build number has been provided in the configuration', function () {
+        it('when no build number has been provided in the configuration', function () {
             releaseMe({
                 repository: 'repo.git',
+                main: './some_repo_code.js',
+                cwd: './source_repo',
+                wd: '.tmp/filesObject',
+                files: {
+                    cwd: './source_repo/packaged',
+                    src: '**/*.js'
+                }
+            });
+        });
+
+        it('when an empty string has been provided as build number in the configuration', function() {
+            releaseMe({
+                repository: 'repo.git',
+                buildNumber: '',
                 main: './some_repo_code.js',
                 cwd: './source_repo',
                 wd: '.tmp/filesObject',


### PR DESCRIPTION
If you use a Grunt template string in the configuration, the returned value will never be `undefined`.
I added a check (parseInt/isNaN) to validate if it's a proper number and consider it undefined otherwise.
