### PR TITLE
Clear bower.json ignore property instead of deleting it

### DIFF
--- a/expects/bower-with-main-array.json
+++ b/expects/bower-with-main-array.json
@@ -1,6 +1,7 @@
 {
   "name": "some_repo",
   "version": "0.1.1",
+  "ignore": [],
   "dependencies": {
     "dependency-a": "1.0.0",
     "dependency-b": "1.1.0"

--- a/expects/bower-without-build-and-sha.json
+++ b/expects/bower-without-build-and-sha.json
@@ -1,6 +1,7 @@
 {
   "name": "some_repo",
   "version": "0.1.1",
+  "ignore": [],
   "dependencies": {
     "dependency-a": "1.0.0",
     "dependency-b": "1.1.0"

--- a/expects/bower.json
+++ b/expects/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "some_repo",
   "version": "0.1.1-build.1+sha.6283298",
+  "ignore": [],
   "dependencies": {
     "dependency-a": "1.0.0",
     "dependency-b": "1.1.0"

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -76,7 +76,7 @@ module.exports = function (grunt) {
                             bowerJSON = grunt.file.readJSON(bowerJsonPath);
                             // clean the bower.json
                             delete bowerJSON.devDependencies;
-                            delete bowerJSON.ignore;
+                            bowerJSON.ignore =  [];
                             // update version and name
                             bowerJSON.name = bowerJSON.name;
                             bowerJSON.main = configuration.main;


### PR DESCRIPTION
Instead of deleting the **ignore** property from bower.json, just clear it.
This property is recommended by the bower.json spec (https://github.com/bower/bower.json-spec#ignore) and will show a warning when not provided.

Closes #6 
